### PR TITLE
renaming prop 'url' to 'id' in the API

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -1,8 +1,8 @@
 ---
+id: web-application
 name: "Web Application"
 root_url: "http://my-jenkins-host/"
 folder: "MyFolderName"
-url: web-application
 jobs:
 - name: Unit Test
   ci_name: MyFolderName-UnitTest

--- a/lib/jenkins_pipeline/app.rb
+++ b/lib/jenkins_pipeline/app.rb
@@ -12,9 +12,9 @@ module JenkinsPipeline
       pipelines.map(&:serialize).to_json
     end
 
-    get '/api/pipelines/:name' do
+    get '/api/pipelines/:id' do
       content_type :json
-      file = pipeline_files.select { |file| file.fetch("url") == params[:name] }.first
+      file = pipeline_files.select { |file| file.fetch("id") == params[:id] }.first
       halt 404 if file.nil?
       pipeline(file).serialize.to_json
     end


### PR DESCRIPTION
in order to keep a name consistency in the configuration and API