### PR TITLE
Use fetched pipelines names endpoint

### DIFF
--- a/client/app/views/index.js
+++ b/client/app/views/index.js
@@ -13,25 +13,24 @@ function appendError(message) {
 
 function hideLoader() { h.$hide('.pipelines-loading'); }
 
-function $fetchPipelineNames() {
-  return h.$getJSON('/api/pipelines/ids').catch(appendError());
+function $fetchPipelineIds() {
+  var errorMsg = 'An error ocurred fetching pipeline ids. Please try again.';
+  return h.$getJSON('/api/pipelines/ids').catch(appendError(errorMsg));
 }
 
 function renderPipelines(pipeline) {
   h.$append('#content-container', renderPipeline(pipeline));
 }
 
-function $fetchPipeline(name) {
-  var errorMsg = 'Fetching Pipeline "' + name + '" failed. Please refresh the page.';
+function $fetchPipeline(id) {
+  var errorMsg = 'Fetching Pipeline "'+id+'" failed. Please refresh the page.';
 
-  return h.$getJSON('/api/pipelines/' + name).
-    then(renderPipelines).
-    catch(appendError(errorMsg));
+  return h.$getJSON('/api/pipelines/'+id).then(renderPipelines).catch(appendError(errorMsg));
 }
 
 function $fetchPipelines() {
-  return $fetchPipelineNames().then(function(names) {
-    return Promise.all(h.map($fetchPipeline, names));
+  return $fetchPipelineIds().then(function(ids) {
+    return Promise.all(h.map($fetchPipeline, ids));
   });
 }
 

--- a/client/app/views/index.js
+++ b/client/app/views/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var h = require('../helpers/helpers');
 var renderPipeline = require('./components/pipelineView').render;
 
@@ -8,59 +7,36 @@ function appendError(message) {
   var errorMsg = message ||  'An error occurred loading the page. Please try again.';
   return function _appendError(err) {
     h.$append('#content-container', errorMsg);
-    h.trace(err);
+    console.log(err);
   };
 }
 
 function hideLoader() { h.$hide('.pipelines-loading'); }
 
-function fetchPipelinesAsync() {
-  function pipelineNames() {
-    return Promise.resolve([
-      'Web Application',
-      'Digital Service',
-      'Transversal Service'
-    ]);
-  }
-
-  function renderPipelines(pipeline) {
-    h.$append('#content-container', renderPipeline(pipeline));
-  }
-
-  function $fetchPipeline(name) {
-    var errorMsg = 'Fetching Pipeline "' + name + '" failed. Please refresh the page.';
-
-    return h.$getJSON('/api/pipelines/' + name).
-             then(renderPipelines).
-             catch(appendError(errorMsg));
-  }
-
-  function $fetchPipelines() {
-    return pipelineNames().then(function(names) {
-      return Promise.all(names.map($fetchPipeline));
-    });
-  }
-
-  return function asyncInit() {
-    $fetchPipelines().catch(appendError()).then(hideLoader);
-  };
+function $fetchPipelineNames() {
+  return h.$getJSON('/api/pipelines/ids').catch(appendError());
 }
 
-// use this until https://github.com/jenkins-pipeline/jenkins-pipeline/issues/31 is done
-function fetchAllPipelinesAtOnce() {
-  var renderView = _.flow(
-    h.map(renderPipeline),
-    h.$setHTML('#content-container')
-  );
+function renderPipelines(pipeline) {
+  h.$append('#content-container', renderPipeline(pipeline));
+}
 
-  return function init() {
-    h.$getJSON('/api/pipelines').
-      then(renderView).
-      catch(appendError()).
-      then(hideLoader);
-  };
+function $fetchPipeline(name) {
+  var errorMsg = 'Fetching Pipeline "' + name + '" failed. Please refresh the page.';
+
+  return h.$getJSON('/api/pipelines/' + name).
+    then(renderPipelines).
+    catch(appendError(errorMsg));
+}
+
+function $fetchPipelines() {
+  return $fetchPipelineNames().then(function(names) {
+    return Promise.all(h.map($fetchPipeline, names));
+  });
 }
 
 module.exports = {
-  init: h.env(location) === 'dev' ? fetchPipelinesAsync() : fetchAllPipelinesAtOnce()
+  init: function() {
+    $fetchPipelines().catch(appendError()).then(hideLoader);
+  }
 };

--- a/client/brunch-server.js
+++ b/client/brunch-server.js
@@ -7,6 +7,7 @@ var logger     = require('morgan');
 var Path       = require('path');
 var find       = require('lodash').find;
 var pipelines  = require('./spec/fixtures/pipelines');
+var PIPELINE_IDS = ['Web Application', 'Digital Service', 'Transversal Service'];
 
 module.exports = function startServer(port, path, callback) {
   var app = express();
@@ -18,6 +19,10 @@ module.exports = function startServer(port, path, callback) {
 
   app.get('/api/pipelines', function(req, res) {
     res.json(pipelines);
+  });
+
+  app.get('/api/pipelines/ids', function(req, res) {
+    res.json(PIPELINE_IDS);
   });
 
   app.get('/api/pipelines/:id', function(req, res) {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jenkins-pipeline-client",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "An attempt to display a set of builds running in Jenkins as a pipeline, a sequence of builds and its states.",
   "scripts": {
     "lint": "esw app/ spec/ --ext .js",


### PR DESCRIPTION
Also this commit removes the feature toggle thus eliminating the fetch of pipelines synchronous. We could probably remove the endpoint `/api/pipelines` from the API as there's no use now.