### PR TITLE
Add rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: .ruby-style.yml

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,6 @@ group :test do
   gem 'rspec'
   gem 'rack-test'
   gem 'webmock'
+  gem 'rubocop', require: false
+  gem 'rake'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
+    ast (2.2.0)
     byebug (5.0.0)
       columnize (= 0.9.0)
     coderay (1.1.0)
@@ -12,6 +13,9 @@ GEM
     dotenv (2.1.0)
     json (1.8.3)
     method_source (0.8.2)
+    parser (2.3.0.6)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -24,6 +28,8 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rainbow (2.1.0)
+    rake (10.5.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -37,6 +43,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    rubocop (0.37.2)
+      parser (>= 2.3.0.4, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 0.3)
+    ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     sinatra (1.4.6)
       rack (~> 1.4)
@@ -44,6 +57,7 @@ GEM
       tilt (>= 1.3, < 3)
     slop (3.6.0)
     tilt (2.0.1)
+    unicode-display_width (0.3.1)
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -56,6 +70,8 @@ DEPENDENCIES
   json
   pry-byebug
   rack-test
+  rake
   rspec
+  rubocop
   sinatra
   webmock

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,3 @@
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new


### PR DESCRIPTION
Add [Rubocop](https://github.com/bbatsov/rubocop) to the project.
Since we are using Hound, it's good to run the same _cops_ during the development time and avoid all complainings after created a PR.

With that now we are able to run `bundle exec rake rubocop` and it will run with the same configurations as we are using on Hound.